### PR TITLE
chore: change installation scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -93,5 +93,5 @@ jobs:
         run: |
           chainloop attestation reset --trigger cancellation
     env:
-      CHAINLOOP_VERSION: 0.8.70
+      CHAINLOOP_VERSION: 0.8.92
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}

--- a/chainloop-demo/github-workflow/release.v1.yaml
+++ b/chainloop-demo/github-workflow/release.v1.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -81,5 +81,5 @@ jobs:
         run: |
           chainloop attestation reset --trigger cancellation
     env:
-      CHAINLOOP_VERSION: 0.8.70
+      CHAINLOOP_VERSION: 0.8.92
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}

--- a/chainloop-demo/github-workflow/release.v2.yaml
+++ b/chainloop-demo/github-workflow/release.v2.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -93,5 +93,5 @@ jobs:
         run: |
           chainloop attestation reset --trigger cancellation
     env:
-      CHAINLOOP_VERSION: 0.8.70
+      CHAINLOOP_VERSION: 0.8.92
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}


### PR DESCRIPTION
Chainloop is now Open Source so we can leverage publicly available releases.

Refs https://github.com/chainloop-dev/chainloop/issues/7